### PR TITLE
more intuitive flow for featured projects

### DIFF
--- a/frontend/src/components/mb-project-card.vue
+++ b/frontend/src/components/mb-project-card.vue
@@ -8,7 +8,7 @@
         mb-avatar.mr-1(size="sm")
         | {{ authorName }}
       div.hidden.text-gray-700.text-base.my-5(style="min-height: 60px; max-height: 60px; height: 60px;") {{ description }}
-      mb-internal-link(:to="'/project/' + id")
+      mb-internal-link(:to="'/project/' + id" target="_blank")
         mb-button.float-right View
       div.flex.justify-left
         div.inline-block.bg-gray-200.rounded-full.px-3.py-1.text-sm.font-semibold.text-gray-700.mr-2(v-for="tag in tags") {{`#${tag}`}}

--- a/frontend/src/views/Project.vue
+++ b/frontend/src/views/Project.vue
@@ -5,7 +5,7 @@ div
       div
         mb-internal-link-arrow.mt-4.mb-2.m-auto(
           :to="eventPage"
-          text="Projects"
+          text="Projects from event"
           left
         )
         h1.text-center.text-4xl.md_text-left.md_text-5xl {{ project.title }}


### PR DESCRIPTION
1. clairty in project back button  ("< Projects" --> "< Projects from event")

![image](https://user-images.githubusercontent.com/9841162/88950584-b3404280-d249-11ea-95b9-99b08e6be8fb.png)


2. opens featured projects in new tab