### PR TITLE
disable front end caching (i think...)

### DIFF
--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -14,7 +14,13 @@ module.exports = {
     },
     disableHostCheck: true // required for nginx to recognize the devserver in local dev mode
   },
-  chainWebpack: (/*config*/) => {
+  chainWebpack: config => {
+    // disable cache in dev and prod (for now)
+    // TODO: reimplement caching by intercepting build version + comparingconfig.module.rule('vue').uses.delete('cache-loader');
+    config.module.rule("vue").uses.delete("cache-loader");
+    config.module.rule("js").uses.delete("cache-loader");
+    config.module.rule("ts").uses.delete("cache-loader");
+    config.module.rule("tsx").uses.delete("cache-loader");
     // // markdown Loader
     // config.module
     //   .rule("markdown")


### PR DESCRIPTION
adding this to `vue.config.js`, per [this](https://stackoverflow.com/questions/54927896/disable-cache-loader-in-webpack-4-vue-cli-3). Will this work? (unsure how to test)

```js
chainWebpack: config => {
    // disable cache in dev and prod (for now)
    // TODO: reimplement caching by intercepting build version + comparing
    config.module.rule("vue").uses.delete("cache-loader");
    config.module.rule("js").uses.delete("cache-loader");
    config.module.rule("ts").uses.delete("cache-loader");
    config.module.rule("tsx").uses.delete("cache-loader");
```