### PR TITLE
remove ref piercing from mb-confirm -> mob-modal

### DIFF
--- a/frontend/src/components/mb-confirm.vue
+++ b/frontend/src/components/mb-confirm.vue
@@ -38,11 +38,11 @@ export default {
   methods: {
     emitConfirmAndClose() {
       this.$emit("confirm");
-      this.$refs.modalBtn.$refs.modal.close();
+      this.$refs.modalBtn.closeModal();
     },
     emitCancelAndClose() {
       this.$emit("cancel");
-      this.$refs.modalBtn.$refs.modal.close();
+      this.$refs.modalBtn.closeModal();
     }
   }
 };

--- a/frontend/src/components/mb-modal-button.vue
+++ b/frontend/src/components/mb-modal-button.vue
@@ -21,6 +21,9 @@ export default {
   methods: {
     openModal() {
       this.$refs.modal.open();
+    },
+    closeModal() {
+      this.$refs.modal.close();
     }
   }
 };

--- a/frontend/src/views/Admin/Admin.vue
+++ b/frontend/src/views/Admin/Admin.vue
@@ -1,7 +1,6 @@
 <template lang="pug">
 main.container.m-auto
   h1.text-5xl Admin Panel
-
   h1.text-2xl.mt-12 Edit Featured Projects Sections
   mb-modal-button.ml-2(btnText="Show me an example" btnVariant="default")
     template(v-slot:title) Example format for featured projects sections
@@ -117,7 +116,8 @@ export default {
         .catch(e => {
           const message =
             // eslint-disable-next-line prettier/prettier
-          (e && e.response && e.response.data && e.response.data.message) || "";
+            (e && e.response && e.response.data && e.response.data.message) ||
+            "";
           console.log("Failed to create event", message, e);
           alert("Failed to create event. " + message);
         });


### PR DESCRIPTION
`mb-confirm` component no longer pierces dependency `mb-modal-button` to close modal.